### PR TITLE
copy build/WW3/ww3_???? to bin and tag with git hashes etc

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
   cmake -S . -B build --preset=gadi -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_VERBOSE_MAKEFILE=ON
   cmake --build build -j 4
 
-  for exec in build/access-om3*; do
+  for exec in build/access-om3* build/WW3/ww3_????; do
     dest=bin/$(basename ${exec})
     if [[ ${BUILD_TYPE} != "Release" ]] ; then dest=${dest}-${BUILD_TYPE}; fi
     dest=${dest}-${hash}


### PR DESCRIPTION
copies WW3 helper apps to bin and labels them with git hashes etc.

https://github.com/COSIMA/access-om3/pull/73#issuecomment-1765467210