### PR TITLE
Fix compilation with CPU specific optimizations

### DIFF
--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -24,7 +24,6 @@ target_sources(OM3_share PRIVATE
   CESM_share/include/shr_assert.h
   CESM_share/src/shr_abort_mod.F90
   CESM_share/src/shr_cal_mod.F90
-  CESM_share/src/shr_const_mod.F90
   CESM_share/src/shr_file_mod.F90
   CESM_share/src/shr_kind_mod.F90
   CESM_share/src/shr_log_mod.F90
@@ -46,6 +45,7 @@ target_sources(OM3_share PRIVATE
   # The following file is a stub.
   stubs/mct_mod.F90
 )
+add_patched_source(OM3_share CESM_share/src/shr_const_mod.F90)
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
   # CESM reduces the precision and increases speed for the following file
   set_source_files_properties(CESM_share/src/shr_wv_sat_mod.F90 PROPERTIES COMPILE_FLAGS "-fimf-precision=low -fp-model fast")

--- a/share/patches/shr_const_mod.F90.patch
+++ b/share/patches/shr_const_mod.F90.patch
@@ -1,0 +1,14 @@
+diff --git a/src/shr_const_mod.F90 b/src/shr_const_mod.F90
+index 8437190..9696c81 100644
+--- shr_const_mod.F90.old
++++ shr_const_mod.F90.new
+@@ -87,9 +87,8 @@ contains
+ !-----------------------------------------------------------------------------
+ 
+   elemental logical function shr_const_isspval(rval)
+-!$omp declare simd(shr_const_isspval)
+ 
+      real(r8), intent(in) :: rval
+ 
+      if (rval > SHR_CONST_SPVAL_TOLMIN .and. &
+          rval < SHR_CONST_SPVAL_TOLMAX) then


### PR DESCRIPTION
Patch shr_const_mod.F90 so that we can compile with CPU specific optimizations on cascade lake.