### PR TITLE
Add option to install components as libraries

### DIFF
--- a/CDEPS/CMakeLists.txt
+++ b/CDEPS/CMakeLists.txt
@@ -102,8 +102,10 @@ if(OM3_LIB_INSTALL)
   # cdeps_common
   set_target_properties(OM3_cdeps_common PROPERTIES
     OUTPUT_NAME access-cdeps-common
+    EXPORT_NAME cdeps-common
   )
   install(TARGETS OM3_cdeps_common
+    EXPORT AccessOM3cdeps_Targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
   )
@@ -111,18 +113,25 @@ if(OM3_LIB_INSTALL)
   foreach(LIB atm ocn ice wav rof)
     set_target_properties(OM3_cdeps_d${LIB} PROPERTIES
       OUTPUT_NAME access-cdeps-d${LIB}
+      EXPORT_NAME cdeps-d${LIB}
     )
     install(TARGETS OM3_cdeps_d${LIB}
+      EXPORT AccessOM3cdeps_Targets
       LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
     )
     # Fortran module files are a special case, as currently there is no standard
     # way of handling them in CMake
-    target_include_directories(OM3_cdeps_d${LIB} PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/access-d${LIB}>")
+    target_include_directories(OM3_cdeps_d${LIB} PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/access-cdeps-d${LIB}>")
     get_target_property(d${LIB}_moddir OM3_cdeps_d${LIB} Fortran_MODULE_DIRECTORY)
     install(FILES ${d${LIB}_moddir}/${LIB}_comp_nuopc.mod
       DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-cdeps-d${LIB}
       COMPONENT AccessOM3_Development
     )
   endforeach()
+  install(EXPORT AccessOM3cdeps_Targets
+    FILE AccessOM3cdepsTargets.cmake
+    NAMESPACE AccessOM3::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AccessOM3
+  )
 endif()

--- a/CDEPS/CMakeLists.txt
+++ b/CDEPS/CMakeLists.txt
@@ -94,3 +94,35 @@ target_link_libraries(OM3_cdeps_drof
 target_sources(OM3_cdeps_drof PRIVATE
   CDEPS/drof/rof_comp_nuopc.F90
 )
+
+### Install and Export
+
+## Library
+if(OM3_LIB_INSTALL)
+  # cdeps_common
+  set_target_properties(OM3_cdeps_common PROPERTIES
+    OUTPUT_NAME access-cdeps-common
+  )
+  install(TARGETS OM3_cdeps_common
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
+  )
+  # components
+  foreach(LIB atm ocn ice wav rof)
+    set_target_properties(OM3_cdeps_d${LIB} PROPERTIES
+      OUTPUT_NAME access-cdeps-d${LIB}
+    )
+    install(TARGETS OM3_cdeps_d${LIB}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
+    )
+    # Fortran module files are a special case, as currently there is no standard
+    # way of handling them in CMake
+    target_include_directories(OM3_cdeps_d${LIB} PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/access-d${LIB}>")
+    get_target_property(d${LIB}_moddir OM3_cdeps_d${LIB} Fortran_MODULE_DIRECTORY)
+    install(FILES ${d${LIB}_moddir}/${LIB}_comp_nuopc.mod
+      DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-cdeps-d${LIB}
+      COMPONENT AccessOM3_Development
+    )
+  endforeach()
+endif()

--- a/CICE/CMakeLists.txt
+++ b/CICE/CMakeLists.txt
@@ -159,8 +159,10 @@ endif()
 if(OM3_LIB_INSTALL)
   set_target_properties(OM3_cice PROPERTIES
     OUTPUT_NAME access-cice
+    EXPORT_NAME cice
   )
   install(TARGETS OM3_cice
+    EXPORT AccessOM3cice_Targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
   )
@@ -172,4 +174,10 @@ if(OM3_LIB_INSTALL)
     DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-cice
     COMPONENT AccessOM3_Development
   )
+  install(EXPORT AccessOM3cice_Targets
+    FILE AccessOM3ciceTargets.cmake
+    NAMESPACE AccessOM3::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AccessOM3
+  )
+
 endif()

--- a/CICE/CMakeLists.txt
+++ b/CICE/CMakeLists.txt
@@ -152,3 +152,24 @@ elseif(OM3_CICE_IO MATCHES "Binary")
     CICE/cicecore/cicedynB/infrastructure/io/io_binary/ice_restart.F90
   )
 endif()
+
+### Install and Export
+
+## Library
+if(OM3_LIB_INSTALL)
+  set_target_properties(OM3_cice PROPERTIES
+    OUTPUT_NAME access-cice
+  )
+  install(TARGETS OM3_cice
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
+  )
+  # Fortran module files are a special case, as currently there is no standard
+  # way of handling them in CMake
+  target_include_directories(OM3_cice PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/access-cice>")
+  get_target_property(cice_moddir OM3_cice Fortran_MODULE_DIRECTORY)
+  install(FILES ${cice_moddir}/ice_comp_nuopc.mod
+    DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-cice
+    COMPONENT AccessOM3_Development
+  )
+endif()

--- a/CMEPS/CMakeLists.txt
+++ b/CMEPS/CMakeLists.txt
@@ -69,8 +69,10 @@ if(OM3_LIB_INSTALL)
   ## CMEPS library
   set_target_properties(OM3_cmeps PROPERTIES
     OUTPUT_NAME access-cmeps
+    EXPORT_NAME cmeps
   )
   install(TARGETS OM3_cmeps
+    EXPORT AccessOM3cmeps_Targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
   )
@@ -82,12 +84,19 @@ if(OM3_LIB_INSTALL)
     DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-cmeps
     COMPONENT AccessOM3_Development
   )
+  install(EXPORT AccessOM3cmeps_Targets
+    FILE AccessOM3cmepsTargets.cmake
+    NAMESPACE AccessOM3::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AccessOM3
+  )
 
   ## NUOPC cap share
   set_target_properties(OM3_nuopc_cap_share PROPERTIES
     OUTPUT_NAME access-nuopc_cap_share
+    EXPORT_NAME nuopc_cap_share
   )
   install(TARGETS OM3_nuopc_cap_share
+    EXPORT AccessOM3nuopc_cap_share_Targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
   )
@@ -98,5 +107,10 @@ if(OM3_LIB_INSTALL)
   install(DIRECTORY ${nuopc_cap_share_moddir}/
     DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-nuopc_cap_share
     COMPONENT AccessOM3_Development
+  )
+  install(EXPORT AccessOM3nuopc_cap_share_Targets
+    FILE AccessOM3nuopc_cap_shareTargets.cmake
+    NAMESPACE AccessOM3::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AccessOM3
   )
 endif()

--- a/CMEPS/CMakeLists.txt
+++ b/CMEPS/CMakeLists.txt
@@ -62,3 +62,41 @@ target_sources(OM3_nuopc_cap_share PRIVATE
   CMEPS/cesm/nuopc_cap_share/glc_elevclass_mod.F90
   CMEPS/cesm/nuopc_cap_share/nuopc_shr_methods.F90
 )
+
+### Install and Export
+
+if(OM3_LIB_INSTALL)
+  ## CMEPS library
+  set_target_properties(OM3_cmeps PROPERTIES
+    OUTPUT_NAME access-cmeps
+  )
+  install(TARGETS OM3_cmeps
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
+  )
+  # Fortran module files are a special case, as currently there is no standard
+  # way of handling them in CMake
+  target_include_directories(OM3_cmeps PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/access-cmeps>")
+  get_target_property(cmeps_moddir OM3_cmeps Fortran_MODULE_DIRECTORY)
+  install(FILES ${cmeps_moddir}/med.mod ${cmeps_moddir}/med_time_mod.mod ${cmeps_moddir}/med_internalstate_mod.mod
+    DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-cmeps
+    COMPONENT AccessOM3_Development
+  )
+
+  ## NUOPC cap share
+  set_target_properties(OM3_nuopc_cap_share PROPERTIES
+    OUTPUT_NAME access-nuopc_cap_share
+  )
+  install(TARGETS OM3_nuopc_cap_share
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
+  )
+  # Fortran module files are a special case, as currently there is no standard
+  # way of handling them in CMake
+  target_include_directories(OM3_nuopc_cap_share PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/access-nuopc_cap_share>")
+  get_target_property(nuopc_cap_share_moddir OM3_nuopc_cap_share Fortran_MODULE_DIRECTORY)
+  install(DIRECTORY ${nuopc_cap_share_moddir}/
+    DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-nuopc_cap_share
+    COMPONENT AccessOM3_Development
+  )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ message(STATUS "  - OM3_CICE_IO       ${OM3_CICE_IO}")
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(GNUInstallDirs)
+if(OM3_LIB_INSTALL)
+  include(CMakePackageConfigHelpers)
+endif()
 
 # Include some custom cmake modules
 include(FortranLib)
@@ -237,4 +240,17 @@ if(OM3_BIN_INSTALL)
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )
   endforeach()
+endif()
+
+# Libraries
+if(OM3_LIB_INSTALL)
+  configure_package_config_file(
+    cmake/AccessOM3Config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/AccessOM3Config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AccessOM3
+  )
+  install(FILES ${CMAKE_SOURCE_DIR}/cmake/FindFoX.cmake ${CMAKE_CURRENT_BINARY_DIR}/AccessOM3Config.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AccessOM3
+    COMPONENT AccessOM3_Development
+  )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,12 @@ add_compile_definitions(
   CESMCOUPLED
 )
 
+## Fortran modules path; currently this is simply set to be the include dir
+set(CMAKE_INSTALL_MODULEDIR ${CMAKE_INSTALL_INCLUDEDIR}
+  CACHE STRING
+  "Fortran module installation path (Not a cmake native variable)"
+)
+
 #[==============================================================================[
 #                              External packages                                #
 #]==============================================================================]
@@ -217,6 +223,10 @@ endforeach()
 #]==============================================================================]
 
 ## Installs
+
+# Note that the installation of some components is done in the corresponding subdirectory
+
+# OM3 executables
 if(OM3_BIN_INSTALL)
   foreach(CONF IN LISTS KnownConfigurations)
     if(NOT OM3_ENABLE_${CONF})

--- a/MOM6/CMakeLists.txt
+++ b/MOM6/CMakeLists.txt
@@ -324,3 +324,24 @@ target_sources(OM3_mom6 PRIVATE
   MOM6/config_src/drivers/nuopc_cap/time_utils.F90
 )
 add_patched_source(OM3_mom6 MOM6/config_src/drivers/nuopc_cap/mom_cap.F90)
+
+### Install and Export
+
+## Library
+if(OM3_LIB_INSTALL)
+  set_target_properties(OM3_mom6 PROPERTIES
+    OUTPUT_NAME access-mom6
+  )
+  install(TARGETS OM3_mom6
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
+  )
+  # Fortran module files are a special case, as currently there is no standard
+  # way of handling them in CMake
+  target_include_directories(OM3_mom6 PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/access-mom6>")
+  get_target_property(mom_moddir OM3_mom6 Fortran_MODULE_DIRECTORY)
+  install(FILES ${mom_moddir}/ocn_comp_nuopc.mod ${mom_moddir}/mom_cap_mod.mod
+    DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-mom6
+    COMPONENT AccessOM3_Development
+  )
+endif()

--- a/MOM6/CMakeLists.txt
+++ b/MOM6/CMakeLists.txt
@@ -331,8 +331,10 @@ add_patched_source(OM3_mom6 MOM6/config_src/drivers/nuopc_cap/mom_cap.F90)
 if(OM3_LIB_INSTALL)
   set_target_properties(OM3_mom6 PROPERTIES
     OUTPUT_NAME access-mom6
+    EXPORT_NAME mom6
   )
   install(TARGETS OM3_mom6
+    EXPORT AccessOM3mom6_Targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
   )
@@ -343,5 +345,10 @@ if(OM3_LIB_INSTALL)
   install(FILES ${mom_moddir}/ocn_comp_nuopc.mod ${mom_moddir}/mom_cap_mod.mod
     DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-mom6
     COMPONENT AccessOM3_Development
+  )
+  install(EXPORT AccessOM3mom6_Targets
+    FILE AccessOM3mom6Targets.cmake
+    NAMESPACE AccessOM3::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AccessOM3
   )
 endif()

--- a/WW3/CMakeLists.txt
+++ b/WW3/CMakeLists.txt
@@ -145,8 +145,10 @@ target_link_libraries(OM3_ww3_ounp PRIVATE AccessOM3::ww3)
 if(OM3_LIB_INSTALL)
   set_target_properties(OM3_ww3 PROPERTIES
     OUTPUT_NAME access-ww3
+    EXPORT_NAME ww3
   )
   install(TARGETS OM3_ww3
+    EXPORT AccessOM3ww3_Targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
   )
@@ -157,6 +159,11 @@ if(OM3_LIB_INSTALL)
   install(FILES ${ww3_moddir}/wav_comp_nuopc.mod
     DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-ww3
     COMPONENT AccessOM3_Development
+  )
+  install(EXPORT AccessOM3ww3_Targets
+    FILE AccessOM3ww3Targets.cmake
+    NAMESPACE AccessOM3::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AccessOM3
   )
 endif()
 

--- a/WW3/CMakeLists.txt
+++ b/WW3/CMakeLists.txt
@@ -139,8 +139,28 @@ set_target_properties(OM3_ww3_ounp PROPERTIES
 )
 target_link_libraries(OM3_ww3_ounp PRIVATE AccessOM3::ww3)
 
+### Install and Export
 
-## Installs
+## Library
+if(OM3_LIB_INSTALL)
+  set_target_properties(OM3_ww3 PROPERTIES
+    OUTPUT_NAME access-ww3
+  )
+  install(TARGETS OM3_ww3
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
+  )
+  # Fortran module files are a special case, as currently there is no standard
+  # way of handling them in CMake
+  target_include_directories(OM3_ww3 PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/access-ww3>")
+  get_target_property(ww3_moddir OM3_ww3 Fortran_MODULE_DIRECTORY)
+  install(FILES ${ww3_moddir}/wav_comp_nuopc.mod
+    DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-ww3
+    COMPONENT AccessOM3_Development
+  )
+endif()
+
+## Utilities
 if(OM3_BIN_INSTALL)
   install(TARGETS OM3_ww3_grid OM3_ww3_strt OM3_ww3_outf OM3_ww3_ounf OM3_ww3_ounp
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/cmake/AccessOM3Config.cmake.in
+++ b/cmake/AccessOM3Config.cmake.in
@@ -1,0 +1,82 @@
+@PACKAGE_INIT@
+
+if(NOT AccessOM3_FIND_QUIETLY)
+  message(STATUS "Found AccessOM3: ${PACKAGE_PREFIX_DIR}")
+endif()
+
+# Available components
+
+# The following components are always available (order is important!)
+set(_supported_components timing share nuopc_cap_share cmeps cdeps mom6 cice ww3)
+
+# Check validity of requested components
+foreach(_comp ${AccessOM3_FIND_COMPONENTS})
+  if (NOT _comp IN_LIST _supported_components)
+    set(AccessOM3_FOUND False)
+    set(AccessOM3_NOT_FOUND_MESSAGE "Unsupported component: ${_comp}")
+  endif()
+endforeach()
+
+# Some components are only available if they were built
+if ((mom6 IN_LIST ${AccessOM3_FIND_COMPONENTS}) AND (NOT @OM3_BUILD_MOM6@))
+  set(AccessOM3_FOUND False)
+  set(AccessOM3_NOT_FOUND_MESSAGE "The following component is not available: mom6")
+endif()
+if ((cice IN_LIST ${AccessOM3_FIND_COMPONENTS}) AND (NOT @OM3_BUILD_CICE6@))
+  set(AccessOM3_FOUND False)
+  set(AccessOM3_NOT_FOUND_MESSAGE "The following component is not available: cice")
+endif()
+if ((ww3 IN_LIST ${AccessOM3_FIND_COMPONENTS}) AND (NOT @OM3_BUILD_WW3@))
+  set(AccessOM3_FOUND False)
+  set(AccessOM3_NOT_FOUND_MESSAGE "The following component is not available: ww3")
+endif()
+
+# Build a list of all the required components, taking into account their dependencies
+set(_required_components ${AccessOM3_FIND_COMPONENTS})
+if(cice IN_LIST _required_components)
+  list(APPEND _required_components cdeps nuopc_cap_share share timing)
+endif()
+if(mom6 IN_LIST _required_components)
+  list(APPEND _required_components nuopc_cap_share share)
+endif()
+if(cdeps IN_LIST _required_components)
+  list(APPEND _required_components cmeps share nuopc_cap_share)
+endif()
+if(cmeps IN_LIST _required_components)
+  list(APPEND _required_components nuopc_cap_share share timing)
+endif()
+if(nuopc_cap_share IN_LIST _required_components)
+  list(APPEND _required_components share timing)
+endif()
+if(share IN_LIST _required_components)
+  list(APPEND _required_components timing)
+endif()
+list(REMOVE_DUPLICATES _required_components)
+
+if(NOT AccessOM3_FIND_QUIETLY)
+  message(STATUS "  - AccessOM3 Components: ${_required_components}")
+endif()
+
+# Include required targets. We do this by looping over the _supported_components
+# list because the order in which targets are loaded matters.
+foreach(_comp ${_supported_components})
+  if (_comp IN_LIST _required_components)
+    include("${CMAKE_CURRENT_LIST_DIR}/AccessOM3${_comp}Targets.cmake")
+  endif()
+endforeach()
+
+# Find dependencies of required components
+include(CMakeFindDependencyMacro)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+if (cdeps IN_LIST _required_components)
+  find_dependency(FoX)
+endif()
+if (mom6 IN_LIST _required_components)
+  find_dependency(fms COMPONENTS R8 REQUIRED)
+endif()
+
+list(REMOVE_ITEM CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+check_required_components(_supported_components)

--- a/cmake/FortranLib.cmake
+++ b/cmake/FortranLib.cmake
@@ -4,5 +4,5 @@ function(add_fortran_library LIB MOD_DIR)
     get_target_property(LIB_DIR ${LIB} BINARY_DIR)
     set_target_properties(${LIB} PROPERTIES Fortran_MODULE_DIRECTORY ${LIB_DIR}/${MOD_DIR})
 
-    target_include_directories(${LIB} INTERFACE ${LIB_DIR}/${MOD_DIR})
-endfunction(add_fortran_library)
+    target_include_directories(${LIB} INTERFACE "$<BUILD_INTERFACE:${LIB_DIR}/${MOD_DIR}>")
+  endfunction(add_fortran_library)

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -3,7 +3,7 @@
 ## share library
 add_fortran_library(OM3_share mod/share STATIC)
 add_library(AccessOM3::share ALIAS OM3_share)
-target_include_directories(OM3_share PUBLIC CESM_share/include)
+target_include_directories(OM3_share PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/CESM_share/include>")
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   target_compile_definitions(OM3_share PRIVATE CPRGNU NAMING=_ADD_UNDERSCORE FORTRANUNDERSCORE)
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
@@ -81,8 +81,10 @@ if(OM3_LIB_INSTALL)
   ## share library
   set_target_properties(OM3_share PROPERTIES
     OUTPUT_NAME access-share
+    EXPORT_NAME share
   )
   install(TARGETS OM3_share
+    EXPORT AccessOM3share_Targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
   )
@@ -94,12 +96,19 @@ if(OM3_LIB_INSTALL)
     DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-share
     COMPONENT AccessOM3_Development
   )
+  install(EXPORT AccessOM3share_Targets
+    FILE AccessOM3shareTargets.cmake
+    NAMESPACE AccessOM3::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AccessOM3
+  )
 
   ## timing library
   set_target_properties(OM3_timing PROPERTIES
     OUTPUT_NAME access-timing
+    EXPORT_NAME timing
   )
   install(TARGETS OM3_timing
+    EXPORT AccessOM3timing_Targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
   )
@@ -110,5 +119,10 @@ if(OM3_LIB_INSTALL)
   install(DIRECTORY ${timing_moddir}/
     DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-timing
     COMPONENT AccessOM3_Development
+  )
+  install(EXPORT AccessOM3timing_Targets
+    FILE AccessOM3timingTargets.cmake
+    NAMESPACE AccessOM3::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/AccessOM3
   )
 endif()

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -74,3 +74,41 @@ target_sources(OM3_timing PRIVATE
   timing/perf_mod.F90
   timing/perf_utils.F90
 )
+
+### Install and Export
+
+if(OM3_LIB_INSTALL)
+  ## share library
+  set_target_properties(OM3_share PROPERTIES
+    OUTPUT_NAME access-share
+  )
+  install(TARGETS OM3_share
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
+  )
+  # Fortran module files are a special case, as currently there is no standard
+  # way of handling them in CMake
+  target_include_directories(OM3_share PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/access-share>")
+  get_target_property(share_moddir OM3_share Fortran_MODULE_DIRECTORY)
+  install(DIRECTORY ${share_moddir}/
+    DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-share
+    COMPONENT AccessOM3_Development
+  )
+
+  ## timing library
+  set_target_properties(OM3_timing PROPERTIES
+    OUTPUT_NAME access-timing
+  )
+  install(TARGETS OM3_timing
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_RunTime NAMELINK_COMPONENT AccessOM3_Development
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT AccessOM3_Development
+  )
+  # Fortran module files are a special case, as currently there is no standard
+  # way of handling them in CMake
+  target_include_directories(OM3_timing PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/access-timing>")
+  get_target_property(timing_moddir OM3_timing Fortran_MODULE_DIRECTORY)
+  install(DIRECTORY ${timing_moddir}/
+    DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-timing
+    COMPONENT AccessOM3_Development
+  )
+endif()


### PR DESCRIPTION
The user now can set the `-DOM3_LIB_INSTALL` option to install the following libraries:
- access-common: common functions needed by all components (share, timing, nuopc_cap_share)
- access-mom6: MOM6
- access-cice: CICE
- access-ww3: WW3
- access-cdeps-*: all the different data models, each as a separate library
- access-cmeps: the mediator (this excludes the nuopc_cap_share modules and all the driver stuff)

This will also install the Fortran modules.