### PR TITLE
Some changes to the build.shs script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,24 +25,14 @@ module load esmf/8.4.2 fms/git.2021.03.01=2021.03.01 parallelio/2.5.10 fortranxm
 module load intel-compiler/${COMPILER_VERSION} openmpi/${OPENMPI_VERSION}
 
 cd ${SCRIPT_DIR}
-INSTALL_DIR=${SCRIPT_DIR}
-
-hash=`git rev-parse --short=7 HEAD`
-test -z "$(git status --porcelain)" || hash=${hash}-modified # uncommitted changes or untracked files
-
 for BUILD_TYPE in "${BUILD_TYPES[@]}"; do
   echo "BUILD_TYPE = "${BUILD_TYPE}
   rm -r build || true
+  INSTALL_DIR=${SCRIPT_DIR}/${BUILD_TYPE}
 
   cmake -S . -B build --preset=gadi -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_VERBOSE_MAKEFILE=ON
   cmake --build build -j 4
   cmake --install build --prefix=${INSTALL_DIR}
 
-  for exec in ${INSTALL_DIR}/bin/*; do
-    dest=${INSTALL_DIR}/bin/$(basename ${exec})
-    if [[ ${BUILD_TYPE} != "Release" ]] ; then dest=${dest}-${BUILD_TYPE}; fi
-    dest=${dest}-${hash}
-    mv ${exec} ${dest}
-    echo "Successfully built ${dest}"
-  done
+  echo "Successfully built ${INSTALL_DIR}"
 done


### PR DESCRIPTION
Some changes to the build.sh script:
 - do not append the git hash to the executable anymore
 - installation is done purely with the "cmake --install"
 - installation directory is now a subdirectory of the directory where the script is to be found, named after the build type (e.g., access-om3/Release)

The idea is that we should now use spack to install Access-OM3 on gadi, so there should be no need of appending the git hashes to the executables.