### PR TITLE
Added IC3 dissipation and IS2 scattering swithces in WW3

### DIFF
--- a/WW3/CMakeLists.txt
+++ b/WW3/CMakeLists.txt
@@ -1,7 +1,7 @@
 ### Global definitions, flags, etc
 
 ## List of switches
-list(APPEND switches "CESMCOUPLED" "NCO" "DIST" "MPI" "PR1" "FLX4" "ST6" "STAB0" "LN1" "NL1" "BT1" "DB1" "MLIM" "TR0" "BS0" "RWND" "WNX1" "WNT1" "CRX1" "CRT1" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS0" "REF0" "NOGRB" "IC0")
+list(APPEND switches "CESMCOUPLED" "DIST" "MPI" "PR1" "FLX4" "ST6" "STAB0" "LN1" "NL1" "BT1" "DB1" "MLIM" "TR0" "BS0" "RWND" "WNX1" "WNT0" "CRX1" "CRT0" "O0" "O1" "O2" "O3" "O4" "O5" "O6" "O7" "O14" "O15" "IS2" "REF0" "NOGRB" "IC3")
 
 ## Global compile definitions
 foreach(switch ${switches})


### PR DESCRIPTION
This PR disables linear interpolation in time for wind and current fields ("WNT0" and "CRT0"). In a coupled configuration, the next time step is unknown and is passed at the coupling frequency by the coupler.

Additionally, the IS2 floe-size dependent scattering model and the IC3 dissipation model is enabled to incorporate sea ice-wave interactions.