### PR TITLE
Fix time history units in WW3 output

### DIFF
--- a/WW3/CMakeLists.txt
+++ b/WW3/CMakeLists.txt
@@ -87,11 +87,12 @@ target_sources(OM3_ww3 PRIVATE
   WW3/model/src/wav_kind_mod.F90
   WW3/model/src/wav_shr_mod.F90
   WW3/model/src/wav_shel_inp.F90
-  WW3/model/src/wav_comp_nuopc.F90
   WW3/model/src/wav_import_export.F90
 
   ${switch_files}
 )
+
+add_patched_source(OM3_ww3 WW3/model/src/wav_comp_nuopc.F90)
 
 ## Utilities
 

--- a/WW3/patches/wav_comp_nuopc.F90.patch
+++ b/WW3/patches/wav_comp_nuopc.F90.patch
@@ -1,0 +1,13 @@
+diff --git a/model/src/wav_comp_nuopc.F90 b/model/src/wav_comp_nuopc.F90
+index 8b9ff5a5..eabdb47f 100644
+--- a/model/src/wav_comp_nuopc.F90
++++ b/model/src/wav_comp_nuopc.F90
+@@ -608,7 +608,7 @@ contains
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
+     endif
+     ! Determine time attributes for history output
+-    call ESMF_TimeGet( esmfTime, timeString=time_origin, calendar=calendar, rc=rc )
++    call ESMF_TimeGet( startTime, timeString=time_origin, calendar=calendar, rc=rc )
+     if (ChkErr(rc,__LINE__,u_FILE_u)) return
+     time_origin = 'seconds since '//time_origin(1:10)//' '//time_origin(12:19)
+     !call ESMF_ClockGet(clock, calendar=calendar)


### PR DESCRIPTION
@ezhilsabareesh8 - here is my proposed patch for ACCESS-NRI/access-om3-configs#287. I broke my configuration and now I can't get this to run at all.

I don't know if this is related to ACCESS-NRI/access-om3-configs#290 ?