### PR TITLE
Set gregorian calednar correctly for CICE

### DIFF
--- a/CICE/CMakeLists.txt
+++ b/CICE/CMakeLists.txt
@@ -127,13 +127,15 @@ target_sources(OM3_cice PRIVATE
   CICE/cicecore/drivers/nuopc/cmeps/CICE_InitMod.F90
   CICE/cicecore/drivers/nuopc/cmeps/CICE_RunMod.F90
   CICE/cicecore/drivers/nuopc/cmeps/cice_wrapper_mod.F90
-  CICE/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
   CICE/cicecore/drivers/nuopc/cmeps/ice_import_export.F90
   CICE/cicecore/drivers/nuopc/cmeps/ice_prescribed_mod.F90
   CICE/cicecore/drivers/nuopc/cmeps/ice_scam.F90
   CICE/cicecore/drivers/nuopc/cmeps/ice_shr_methods.F90
 )
+
 add_patched_source(OM3_cice CICE/cicecore/drivers/nuopc/cmeps/ice_mesh_mod.F90)
+add_patched_source(OM3_cice CICE/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90)
+
 # Select IO source files based on CICE_IO
 if(OM3_CICE_IO MATCHES "NetCDF")
   target_sources(OM3_cice PRIVATE

--- a/CICE/patches/ice_comp_nuopc.F90.patch
+++ b/CICE/patches/ice_comp_nuopc.F90.patch
@@ -1,0 +1,56 @@
+diff --git a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90 b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+index b94fcff0..af9e4a36 100644
+--- a/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
++++ b/cicecore/drivers/nuopc/cmeps/ice_comp_nuopc.F90
+@@ -23,10 +23,10 @@ module ice_comp_nuopc
+   use ice_domain_size    , only : nx_global, ny_global
+   use ice_grid           , only : grid_format, init_grid2
+   use ice_communicate    , only : init_communicate, my_task, master_task, mpi_comm_ice
+-  use ice_calendar       , only : force_restart_now, write_ic, init_calendar
+-  use ice_calendar       , only : idate, mday, mmonth, myear, year_init
++  use ice_calendar       , only : force_restart_now, write_ic
++  use ice_calendar       , only : idate, idate0,  mday, mmonth, myear, year_init, month_init, day_init
+   use ice_calendar       , only : msec, dt, calendar, calendar_type, nextsw_cday, istep
+-  use ice_calendar       , only : ice_calendar_noleap, ice_calendar_gregorian
++  use ice_calendar       , only : ice_calendar_noleap, ice_calendar_gregorian, use_leap_years
+   use ice_kinds_mod      , only : dbl_kind, int_kind, char_len, char_len_long
+   use ice_fileunits      , only : nu_diag, nu_diag_set, inst_index, inst_name
+   use ice_fileunits      , only : inst_suffix, release_all_fileunits, flush_fileunit
+@@ -746,7 +746,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
+     call cice_init2()
+     call t_stopf ('cice_init2')
+     !---------------------------------------------------------------------------
+-    ! use EClock to reset calendar information on initial start
++    ! use EClock to reset calendar information
+     !---------------------------------------------------------------------------
+ 
+     ! - on initial run
+@@ -762,7 +762,7 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
+        if (ref_ymd /= start_ymd .or. ref_tod /= start_tod) then
+           if (my_task == master_task) then
+              write(nu_diag,*) trim(subname),': ref_ymd ',ref_ymd, ' must equal start_ymd ',start_ymd
+-             write(nu_diag,*) trim(subname),': ref_ymd ',ref_tod, ' must equal start_ymd ',start_tod
++             write(nu_diag,*) trim(subname),': ref_tod',ref_tod, ' must equal start_tod ',start_tod
+           end if
+        end if
+ 
+@@ -794,6 +794,19 @@ subroutine InitializeRealize(gcomp, importState, exportState, clock, rc)
+ 
+     end if
+ 
++    !  - start time from ESMF clock. Used to set history time units
++    idate0    = start_ymd
++    year_init = (idate0/10000)
++    month_init= (idate0-year_init*10000)/100           ! integer month of basedate
++    day_init  = idate0-year_init*10000-month_init*100 
++
++    !  - Set use_leap_years based on calendar (as some CICE calls use this instead of the calendar type)
++    if (calendar_type == ice_calendar_gregorian) then
++      use_leap_years = .true.
++    else
++      use_leap_years = .false. ! no_leap calendars
++    endif
++
+     call calendar()     ! update calendar info
+ 
+     !----------------------------------------------------------------------------


### PR DESCRIPTION
This change sets the 'time:units' and the 'time:calendar'' attributes of the history output consistent with the nuopc.runconfig file

Patch is cherry-picked from https://github.com/CICE-Consortium/CICE/pull/936

Closes #111 