### PR TITLE
Fix WW3 failing restart

### DIFF
--- a/WW3/CMakeLists.txt
+++ b/WW3/CMakeLists.txt
@@ -44,7 +44,6 @@ target_sources(OM3_ww3 PRIVATE
   WW3/model/src/w3iogomd.F90
   WW3/model/src/w3iogrmd.F90
   WW3/model/src/w3iopomd.F90
-  WW3/model/src/w3iorsmd.F90
   WW3/model/src/w3iosfmd.F90
   WW3/model/src/w3iotrmd.F90
   WW3/model/src/w3macros.h

--- a/WW3/CMakeLists.txt
+++ b/WW3/CMakeLists.txt
@@ -94,6 +94,8 @@ target_sources(OM3_ww3 PRIVATE
   ${switch_files}
 )
 
+add_patched_source(OM3_ww3 WW3/model/src/w3iorsmd.F90)
+
 ## Utilities
 
 # ww3_grid

--- a/WW3/patches/w3iorsmd.F90.patch
+++ b/WW3/patches/w3iorsmd.F90.patch
@@ -1,0 +1,22 @@
+diff --git a/w3iorsmd.F90 b/w3iorsmd.F90.new
+index ffb34d47..0e32748b 100644
+--- a/w3iorsmd.F90
++++ b/w3iorsmd.F90.new
+@@ -893,7 +893,7 @@ CONTAINS
+           WRITEBUFF(:) = 0.
+           WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR) WRITEBUFF
+           WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)           &
+-               TLEV, TICE, TRHO
++               TLEV, TICE, TRHO, TIC1, TIC5
+           DO IPART=1,NPART
+             NREC  = NREC + 1
+             RPOS  = 1_8 + LRECL*(NREC-1_8)
+@@ -1078,7 +1078,7 @@ CONTAINS
+       IF (TYPE.EQ.'FULL') THEN
+         RPOS = 1_8 + LRECL*(NREC-1_8)
+         READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)                &
+-             TLEV, TICE, TRHO
++             TLEV, TICE, TRHO, TIC1, TIC5
+         DO IPART=1,NPART
+           NREC  = NREC + 1
+           RPOS = 1_8 + LRECL*(NREC-1_8)


### PR DESCRIPTION
This PR fixes #97 by adding ice thickness (IC1) and floe diameter (IC5) to the restart write and read routines of WW3.