### PR TITLE
Allow `salt_flux_added` to be used by generic tracers

### DIFF
--- a/MOM6/CMakeLists.txt
+++ b/MOM6/CMakeLists.txt
@@ -65,7 +65,6 @@ target_sources(OM3_mom6 PRIVATE
   MOM6/src/core/MOM_dynamics_unsplit.F90
   MOM6/src/core/MOM_dynamics_unsplit_RK2.F90
   MOM6/src/core/MOM.F90
-  MOM6/src/core/MOM_forcing_type.F90
   MOM6/src/core/MOM_grid.F90
   MOM6/src/core/MOM_interface_heights.F90
   MOM6/src/core/MOM_isopycnal_slopes.F90
@@ -375,6 +374,7 @@ add_patched_source(OM3_mom6 MOM6/config_src/drivers/nuopc_cap/mom_ocean_model_nu
 add_patched_source(OM3_mom6 MOM6/config_src/infra/FMS2/MOM_couplertype_infra.F90)
 add_patched_source(OM3_mom6 MOM6/src/framework/MOM_coupler_types.F90)
 add_patched_source(OM3_mom6 MOM6/src/tracer/MOM_generic_tracer.F90)
+add_patched_source(OM3_mom6 MOM6/src/core/MOM_forcing_type.F90)
 
 ### Install and Export
 

--- a/MOM6/patches/MOM_forcing_type.F90.patch
+++ b/MOM6/patches/MOM_forcing_type.F90.patch
@@ -1,0 +1,16 @@
+diff --git a/MOM6/src/core/MOM_forcing_type.F90 b/MOM6/src/core/MOM_forcing_type.F90.new
+index 200bbd7..fca9187 100644
+--- a/MOM6/src/core/MOM_forcing_type.F90
++++ b/MOM6/src/core/MOM_forcing_type.F90.new
+@@ -2080,6 +2080,11 @@ subroutine fluxes_accumulate(flux_tmp, fluxes, G, wt2, forces)
+ 
+     fluxes%salt_flux(i,j) = wt1*fluxes%salt_flux(i,j) + wt2*flux_tmp%salt_flux(i,j)
+   enddo ; enddo
++  if (associated(fluxes%salt_flux_added) .and. associated(flux_tmp%salt_flux_added)) then
++    do j=js,je ; do i=is,ie
++      fluxes%salt_flux_added(i,j) = wt1*fluxes%salt_flux_added(i,j) + wt2*flux_tmp%salt_flux_added(i,j)
++    enddo ; enddo
++  endif
+   if (associated(fluxes%heat_added) .and. associated(flux_tmp%heat_added)) then
+     do j=js,je ; do i=is,ie
+       fluxes%heat_added(i,j) = wt1*fluxes%heat_added(i,j) + wt2*flux_tmp%heat_added(i,j)

--- a/MOM6/patches/MOM_generic_tracer.F90.patch
+++ b/MOM6/patches/MOM_generic_tracer.F90.patch
@@ -1,7 +1,16 @@
 diff --git a/MOM6/src/tracer/MOM_generic_tracer.F90 b/MOM6/src/tracer/MOM_generic_tracer.F90.new
-index 131110e..7334a56 100644
+index 131110e..ae75b2e 100644
 --- a/MOM6/src/tracer/MOM_generic_tracer.F90
 +++ b/MOM6/src/tracer/MOM_generic_tracer.F90.new
+@@ -21,7 +21,7 @@ module MOM_generic_tracer
+   use generic_tracer, only: generic_tracer_coupler_get, generic_tracer_coupler_set
+   use generic_tracer, only: generic_tracer_end, generic_tracer_get_list, do_generic_tracer
+   use generic_tracer, only: generic_tracer_update_from_bottom,generic_tracer_vertdiff_G
+-  use generic_tracer, only: generic_tracer_coupler_accumulate
++  use generic_tracer, only: generic_tracer_coupler_accumulate, generic_tracer_update_from_coupler
+ 
+   use g_tracer_utils,   only: g_tracer_get_name,g_tracer_set_values,g_tracer_set_common,g_tracer_get_common
+   use g_tracer_utils,   only: g_tracer_get_next,g_tracer_type,g_tracer_is_prog,g_tracer_flux_init
 @@ -352,7 +352,9 @@ contains
            enddo ; enddo ; enddo
  
@@ -13,3 +22,15 @@ index 131110e..7334a56 100644
              do k=2,nk ; do j=jsc,jec ; do i=isc,iec
                if (tr_ptr(i,j,k) /= CS%tracer_land_val) then
                  tr_ptr(i,j,k) = 0.0
+@@ -507,6 +509,11 @@ contains
+     !      the fluxes without coming into this subroutine.
+     !      MOM5 has to modified to conform.
+ 
++    !
++    !Call the generic_tracer's update_from_coupler routine (convert salt_flux_added to g/m^2/sec)
++    !
++    call generic_tracer_update_from_coupler(G%isd, G%jsd, 1000*(US%RZ_T_to_kg_m2s*fluxes%salt_flux_added))
++
+     !
+     !Add contribution of river to surface flux
+     !


### PR DESCRIPTION
We've recently [suggested changes to NOAA-GFDL/ocean_BGC `generic_tracers`](https://github.com/NOAA-GFDL/ocean_BGC/pull/35) to provide a way to pass the salt restoring/correction applied by the ocean model to generic tracers. Those proposed changes add a new subroutine `generic_tracer::generic_tracer_update_from_coupler` that receives the salt flux and passes it on the generic tracer's `update_from_coupler` routine if it is needed. Currently this feature is only utilised by the WOMBAT generic tracers which exist in [the ACCESS-NRI fork of NOAA-GFDL/ocean_BGC](https://github.com/ACCESS-NRI/GFDL-generic-tracers).

To use this feature requires corresponding changes to the calling ocean model. In MOM6, the changes are as follows

- accumulate the added salt flux in `MOM_forcing_type::fluxes_accumulate`
- pass the accumulated flux to the new `generic_tracer::generic_tracer_coupler_accumulate` routine at the start of `MOM_generic_tracer::MOM_generic_tracer_column_physics`.

This PR implements these changes in ACCESS-OM3 via patches.

Note, it would be good in the long run to have these changes included in the authoritative MOM6. However, this should only happen if/when `generic_tracer::generic_tracer_update_from_coupler` is available in NOAA-GFDL/ocean_BGC.