### PR TITLE
Remove .h from CICE history output filenames

### DIFF
--- a/CICE/CMakeLists.txt
+++ b/CICE/CMakeLists.txt
@@ -61,7 +61,6 @@ target_sources(OM3_cice PRIVATE
   CICE/cicecore/cicedyn/general/ice_flux_bgc.F90
   CICE/cicecore/cicedyn/general/ice_forcing.F90
   CICE/cicecore/cicedyn/general/ice_forcing_bgc.F90
-  CICE/cicecore/cicedyn/general/ice_init.F90
   CICE/cicecore/cicedyn/general/ice_state.F90
   CICE/cicecore/cicedyn/general/ice_step_mod.F90
 
@@ -155,6 +154,7 @@ endif()
 
 add_patched_source(OM3_cice CICE/cicecore/cicedyn/infrastructure/ice_domain.F90)
 add_patched_source(OM3_cice CICE/cicecore/shared/ice_distribution.F90)
+add_patched_source(OM3_cice CICE/cicecore/cicedyn/general/ice_init.F90)
 
 ### Install and Export
 

--- a/CICE/patches/ice_init.F90.patch
+++ b/CICE/patches/ice_init.F90.patch
@@ -1,0 +1,13 @@
+diff --git a/cicecore/cicedyn/general/ice_init.F90 b/cicecore/cicedyn/general/ice_init.F90
+index 24ac40db..4ad296aa 100644
+--- a/cicecore/cicedyn/general/ice_init.F90
++++ b/cicecore/cicedyn/general/ice_init.F90
+@@ -872,7 +872,7 @@ subroutine input_data
+       ! runid and runtype are obtained from the driver, not from the namelist
+ 
+       if (my_task == master_task) then
+-         history_file  = trim(runid) // ".cice" // trim(inst_suffix) //".h"
++         history_file  = trim(runid) // ".cice" // trim(inst_suffix)
+          restart_file  = trim(runid) // ".cice" // trim(inst_suffix) //".r"
+          incond_file   = trim(runid) // ".cice" // trim(inst_suffix) //".i"
+          ! Note by tcraig - this if test is needed because the nuopc cap sets


### PR DESCRIPTION
Per https://github.com/COSIMA/access-om3/issues/190#issuecomment-2261753828 , remove .h. from the output filenames of CICE