### PR TITLE
changed mom6 submodule to direct towards access-nri repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "MOM6/MOM6"]
 	path = MOM6/MOM6
-	url = https://github.com/NCAR/MOM6
+	url = https://github.com/ACCESS-NRI/mom6
 [submodule "CICE6/CICE6"]
 	path = CICE/CICE
 	url = https://github.com/ESCOMP/CICE


### PR DESCRIPTION
Changed mom6 submodule to direct towards access-nri repo. Tested successfully running [COSIMA version](https://github.com/COSIMA/access-om3) (`f3958e7f513fbd88e491ece5f6a7ea2b9b719201`) and with the update from this repo, using config `dev-1deg_jra55do_ryf` [see config.yaml for a few changes](https://github.com/user-attachments/files/17389301/config.yaml.txt). **md5hash is ok on MOM and CICE restart files** but not executable (below).

MOM restart
```
[2127][cyb561.gadi-login-06: access-om3]$ md5sum oldver/archive/restart000/access-om3.mom6.r.1900-02-01-00000.nc 
109eb4966c0bdd5e9b9bd76c2cff4b5b  oldver/archive/restart000/access-om3.mom6.r.1900-02-01-00000.nc
[2128][cyb561.gadi-login-06: access-om3]$ md5sum newver/archive/restart000/access-om3.mom6.r.1900-02-01-00000.nc 
109eb4966c0bdd5e9b9bd76c2cff4b5b  newver/archive/restart000/access-om3.mom6.r.1900-02-01-00000.nc
```

CICE restart
```
[2129][cyb561.gadi-login-06: access-om3]$ md5sum oldver/archive/restart000/access-om3.cice.r.1900-02-01-00000.nc 
380dfdd050a4e0a76ef4e9f4b7ad2ca4  oldver/archive/restart000/access-om3.cice.r.1900-02-01-00000.nc
[2130][cyb561.gadi-login-06: access-om3]$ md5sum newver/archive/restart000/access-om3.cice.r.1900-02-01-00000.nc 
380dfdd050a4e0a76ef4e9f4b7ad2ca4  newver/archive/restart000/access-om3.cice.r.1900-02-01-00000.nc
```

Minor point: md5 does not work on executable
```
#cosima version
[cyb561.gadi-login-06: Release]$ md5sum bin/access-om3-MOM6-CICE6
f168e26d78049d765c913016e2a3896a  bin/access-om3-MOM6-CICE6

#this version
[cyb561.gadi-login-05: Release]$ md5sum bin/access-om3-MOM6-CICE6
d0dcc6c7d79ed7e1e744028cad0ad5d2  bin/access-om3-MOM6-CICE6
```
Note that the .git folders change with fresh clones of the repos but not the MOM code folder -- [see diff here.](https://github.com/user-attachments/files/17389259/diff.txt) @aidanheerdegen suggested it's likely due to compiler build processes (e.g. timestamps in build process).