### PR TITLE
Truncation Output Issue: Fileset Flag and Filename Handling

### DIFF
--- a/MOM6/CMakeLists.txt
+++ b/MOM6/CMakeLists.txt
@@ -375,7 +375,8 @@ add_patched_source(OM3_mom6 MOM6/config_src/infra/FMS2/MOM_couplertype_infra.F90
 add_patched_source(OM3_mom6 MOM6/src/framework/MOM_coupler_types.F90)
 add_patched_source(OM3_mom6 MOM6/src/tracer/MOM_generic_tracer.F90)
 add_patched_source(OM3_mom6 MOM6/src/core/MOM_forcing_type.F90)
-
+add_patched_source(OM3_mom6 MOM6/config_src/infra/FMS2/MOM_io_infra.F90)
+add_patched_source(OM3_mom6 MOM6/src/diagnostics/MOM_PointAccel.F90)
 ### Install and Export
 
 ## Library

--- a/MOM6/patches/MOM_PointAccel.F90.patch
+++ b/MOM6/patches/MOM_PointAccel.F90.patch
@@ -1,0 +1,24 @@
+--- ../MOM6/src/diagnostics/MOM_PointAccel.F90	2024-10-23 10:07:22.000000000 +1100
++++ ../MOM6/src/diagnostics/MOM_PointAccel.F90.new	2024-10-23 10:15:54.000000000 +1100
+@@ -122,8 +122,8 @@
+     if (CS%u_file < 0) then
+       if (len_trim(CS%u_trunc_file) < 1) return
+       call open_ASCII_file(CS%u_file, trim(CS%u_trunc_file), action=APPEND_FILE, &
+-                           threading=MULTIPLE, fileset=SINGLE_FILE)
+-      if (CS%u_file < 0) then
++                           threading=MULTIPLE, fileset=MULTIPLE)
++      if (CS%u_file == -1) then
+         call MOM_error(NOTE, 'Unable to open file '//trim(CS%u_trunc_file)//'.')
+         return
+       endif
+@@ -461,8 +461,8 @@
+     if (CS%v_file < 0) then
+       if (len_trim(CS%v_trunc_file) < 1) return
+       call open_ASCII_file(CS%v_file, trim(CS%v_trunc_file), action=APPEND_FILE, &
+-                           threading=MULTIPLE, fileset=SINGLE_FILE)
+-      if (CS%v_file < 0) then
++                           threading=MULTIPLE, fileset=MULTIPLE)
++      if (CS%v_file == -1) then
+         call MOM_error(NOTE, 'Unable to open file '//trim(CS%v_trunc_file)//'.')
+         return
+       endif

--- a/MOM6/patches/MOM_io_infra.F90.patch
+++ b/MOM6/patches/MOM_io_infra.F90.patch
@@ -1,0 +1,27 @@
+--- ../MOM6/config_src/infra/FMS2/MOM_io_infra.F90	2024-10-23 10:07:33.000000000 +1100
++++ ../MOM6/config_src/infra/FMS2/MOM_io_infra.F90.new	2024-10-23 10:16:45.000000000 +1100
+@@ -376,8 +376,7 @@
+   logical :: exists
+   logical :: is_open
+   character(len=6) :: action_arg, position_arg
+-  character(len=:), allocatable :: filename
+-
++  character(len=50) :: filename
+   ! NOTE: This function is written to emulate the original behavior of mpp_open
+   !   from the FMS1 library, on which the MOM API is still based.  Much of this
+   !   can be removed if we choose to drop this compatibility, but for now we
+@@ -433,12 +432,12 @@
+     endif
+   endif
+ 
+-  inquire(file=filename, exist=exists)
++  inquire(file=trim(filename), exist=exists)
+   if (exists .and. action_flag == WRITEONLY_FILE) &
+     call MOM_error(WARNING, 'open_ASCII_file: File ' // trim(filename) // &
+                             ' opened WRITEONLY already exists!')
+ 
+-  open(newunit=unit, file=filename, action=trim(action_arg), &
++  open(newunit=unit, file=trim(filename), action=trim(action_arg), &
+        position=trim(position_arg))
+ 
+   ! This checks if open() failed but did not raise a runtime error.

--- a/MOM6/patches/MOM_io_infra.F90.patch
+++ b/MOM6/patches/MOM_io_infra.F90.patch
@@ -6,7 +6,7 @@
    character(len=6) :: action_arg, position_arg
 -  character(len=:), allocatable :: filename
 -
-+  character(len=50) :: filename
++  character(len=500) :: filename
    ! NOTE: This function is written to emulate the original behavior of mpp_open
    !   from the FMS1 library, on which the MOM API is still based.  Much of this
    !   can be removed if we choose to drop this compatibility, but for now we


### PR DESCRIPTION
In the current version of MOM6 with FMS2, truncation outputs are not produced when the `fileset` flag is set to `SINGLE_FILE`. This PR address issue [736](https://github.com/NOAA-GFDL/MOM6/issues/736) by setting the `MULTIPLE` and fixing the file handle check in `MOM_PointAccel.F90`. 

Note that this is a temporary fix to produce the truncation output by setting the `fileset` to`MULTIPLE`.  The patches can be removed when the official fix is updated in MOM6.