### PR TITLE
Remove duplicated entries in CMakeLists.txt

### DIFF
--- a/MOM6/CMakeLists.txt
+++ b/MOM6/CMakeLists.txt
@@ -83,7 +83,6 @@ target_sources(OM3_mom6 PRIVATE
   MOM6/src/diagnostics/MOM_diagnostics.F90
   MOM6/src/diagnostics/MOM_obsolete_diagnostics.F90
   MOM6/src/diagnostics/MOM_obsolete_params.F90
-  MOM6/src/diagnostics/MOM_PointAccel.F90
   MOM6/src/diagnostics/MOM_spatial_means.F90
   MOM6/src/diagnostics/MOM_sum_output.F90
   MOM6/src/diagnostics/MOM_wave_speed.F90
@@ -358,7 +357,6 @@ target_sources(OM3_mom6 PRIVATE
   MOM6/config_src/infra/FMS2/MOM_ensemble_manager_infra.F90
   MOM6/config_src/infra/FMS2/MOM_error_infra.F90
   MOM6/config_src/infra/FMS2/MOM_interp_infra.F90
-  MOM6/config_src/infra/FMS2/MOM_io_infra.F90
   MOM6/config_src/infra/FMS2/MOM_time_manager.F90
 
   MOM6/config_src/drivers/nuopc_cap/mom_cap_time.F90


### PR DESCRIPTION
The files `MOM_PointAccel.F90` and `MOM_io_infra.F90` are duplicated in the CMake configuration with the following entries:

```cmake
add_patched_source(OM3_mom6 MOM6/config_src/infra/FMS2/MOM_io_infra.F90)
add_patched_source(OM3_mom6 MOM6/src/diagnostics/MOM_PointAccel.F90)
```