### PR TITLE
Remove reference to med_time_mod.mod during library builds

### DIFF
--- a/CMEPS/CMakeLists.txt
+++ b/CMEPS/CMakeLists.txt
@@ -79,7 +79,7 @@ if(OM3_LIB_INSTALL)
   # way of handling them in CMake
   target_include_directories(OM3_cmeps PUBLIC "$<INSTALL_INTERFACE:${CMAKE_INSTALL_MODULEDIR}/access-cmeps>")
   get_target_property(cmeps_moddir OM3_cmeps Fortran_MODULE_DIRECTORY)
-  install(FILES ${cmeps_moddir}/med.mod ${cmeps_moddir}/med_time_mod.mod ${cmeps_moddir}/med_internalstate_mod.mod
+  install(FILES ${cmeps_moddir}/med.mod ${cmeps_moddir}/med_internalstate_mod.mod
     DESTINATION ${CMAKE_INSTALL_MODULEDIR}/access-cmeps
     COMPONENT AccessOM3_Development
   )


### PR DESCRIPTION
Closes #292

This PR removes the reference to `med_time_mod.mod` which is used when building OM3 libraries. This reference causes the build to fail, as the corresponding source code is no longer part of CMEPs. 

See [here](https://github.com/ACCESS-NRI/ACCESS-OM3/pull/57#issuecomment-2702484173) for an example of a successful build using the changes from this PR. 